### PR TITLE
Add the class "form-control" to the select element

### DIFF
--- a/arrayTextAdapt.php
+++ b/arrayTextAdapt.php
@@ -328,6 +328,7 @@ class arrayTextAdapt  extends \ls\pluginmanager\PluginBase {
                     $data['']=gT('No answer');
                 }
                 $htmlOptions['id']='answer'.$inputDom->getAttribute("name");
+                $htmlOptions['class']='form-control';
                 $newHtml=CHtml::dropDownList(
                     $inputDom->getAttribute("name"), $inputDom->getAttribute("value"),
                     $data,


### PR DESCRIPTION
This is necessary for the newer templates based on bootstrap. Otherwise the select-element drop-down does not look consistent.